### PR TITLE
DCS-266 deploy to preprod and prod environments.  

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/probationteams/config/ResourceServerConfiguration.java
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/config/ResourceServerConfiguration.java
@@ -42,7 +42,7 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
                 .antMatchers(
                         "/webjars/**",
                         "/favicon.ico",
-                        "/health/ping",
+                        "/health/**",
                         "/h2-console/**",
                         "/v2/api-docs",
                         "/swagger-ui.html",

--- a/src/main/java/uk/gov/justice/hmpps/probationteams/config/ResourceServerConfiguration.java
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/config/ResourceServerConfiguration.java
@@ -43,6 +43,7 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
                         "/webjars/**",
                         "/favicon.ico",
                         "/health/**",
+                        "/info",
                         "/h2-console/**",
                         "/v2/api-docs",
                         "/swagger-ui.html",


### PR DESCRIPTION
Allow '/health/**', ie ''/health' as well as '/health/ping'