### PR TITLE
 DCS-337 Add missing FMB for N02/YSNYOR

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,13 +40,10 @@ repositories {
 dependencies {
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-    annotationProcessor("org.projectlombok:lombok:1.18.10")
 
     runtimeOnly("com.h2database:h2:1.4.200")
     runtimeOnly("org.flywaydb:flyway-core:6.2.0")
     runtimeOnly("org.postgresql:postgresql:42.2.9")
-
-    compileOnly("org.projectlombok:lombok:1.18.10")
 
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
@@ -73,9 +70,6 @@ dependencies {
     implementation("com.pauldijou:jwt-core_2.11:4.2.0")
 
     testAnnotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.10")
-
-    testCompileOnly("org.projectlombok:lombok:1.18.10")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,6 @@
+probation-teams is a bash script that can be used to query, update and delete functional mailboxes.
+It is pre-configured to work with the 'licences-dev', 'licences-preprod' and 'licenes-prod' namespaces. 
+
+It depends upon jq and kubectl, both of which must be on the shell PATH
+
+The script uses kubectl to read secrets from the relevant namespace which it uses to request a token from the auth server.

--- a/scripts/probation-teams
+++ b/scripts/probation-teams
@@ -67,7 +67,8 @@ read_command_line() {
         -team )     shift
                     TEAM_CODE=$1
                     ;;
-        -update )   COMMAND=update
+        -update )   shift
+                    COMMAND=update
                     EMAIL=$1
                     ;;
         -delete )   COMMAND=delete
@@ -138,16 +139,15 @@ confirm() {
 }
 
 get_ldu() {
-  # echo "GET ${BASE_URL}"
-  confirm
+  echo "GET ${BASE_URL}"
   curl -s -H "${AUTH_HEADER}" -X HEAD ${BASE_URL} -w 'HTTP status: %{http_code}\n'
   curl -s -H "${AUTH_HEADER}" -X GET ${BASE_URL} | jq
 }
 
 update_mailbox() {
   if [ $EMAIL ]; then
-    # echo "PUT ${EMAIL}"
-    # echo "  to ${BASE_URL}/functional-mailbox"
+    echo "PUT ${EMAIL}"
+    echo "  to ${BASE_URL}/functional-mailbox"
     confirm
     curl -s -H "${AUTH_HEADER}" -X PUT ${BASE_URL}/functional-mailbox -H 'Content-Type: application/json' -d \"${EMAIL}\" -w 'HTTP status: %{http_code}\n'
   else
@@ -157,7 +157,7 @@ update_mailbox() {
 }
 
 delete_mailbox() {
-  # echo "DELETE ${BASE_URL}/functional-mailbox"
+  echo "DELETE ${BASE_URL}/functional-mailbox"
   confirm
   curl -s -H "${AUTH_HEADER}" -X DELETE ${BASE_URL}/functional-mailbox -w 'HTTP status: %{http_code}\n'
 

--- a/scripts/probation-teams
+++ b/scripts/probation-teams
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+declare -A AUTH_URL
+declare -A PROBATION_TEAMS_URL
+
+# DEV
+AUTH_URL['dev']=https://gateway.t3.nomis-api.hmpps.dsd.io/auth
+PROBATION_TEAMS_URL['dev']=https://probation-teams-dev.prison.service.justice.gov.uk
+
+#PREPROD
+AUTH_URL['preprod']=https://gateway.preprod.nomis-api.service.hmpps.dsd.io/auth
+PROBATION_TEAMS_URL['preprod']=https://probation-teams-preprod.prison.service.justice.gov.uk
+
+#PROD
+AUTH_URL['prod']=https://gateway.prod.nomis-api.service.hmpps.dsd.io/auth
+PROBATION_TEAMS_URL['prod']=https://probation-teams.prison.service.justice.gov.uk
+
+usage() {
+  echo
+  echo "Usage:"
+  echo
+  echo " command line parameters:"
+  echo
+  echo "   -ns <namespace>            One of 'dev', 'preprod' or 'prod'. Selects the kubernetes namespace. "
+  echo "                              If 'prod' is selected the user is asked to confirm the operation"
+  echo "   -pa <probation area code>  Required"
+  echo "   -ldu <LDU code>            Required"
+  echo "   -team <team code>          Required when a team functional mailbox is to be updated or deleted"
+  echo "   -update <email address>    PUT the email address to the selected LDU or team functional mailbox"
+  echo "   -delete                    DELETE the selected LDU or team functional mailbox"
+  echo
+  echo "  Examples:"
+  echo
+  echo "  GET the LDU resource for probation area 'N02' and LDU 'YSNYOR':"
+  echo "  probation-teams -ns dev -pa N02 -ldu YSNYOR"
+  echo
+  echo "  Update the functional mailbox for N02/YSNYOR:"
+  echo "  probation-teams -ns dev -pa N02 -ldu YSNYOR -update <abc@def.org>"
+  echo
+  echo "  DELETE the functional mailbox at N02/YSNYOR:"
+  echo "  probation-teams -ns dev -pa N02 -ldu YSNYOR -delete"
+  echo
+  echo "  Update a team's functional mailbox:"
+  echo "  probation-teams -ns dev -pa N02 -ldu YSNYOR -team T1 -update <pqr@def.org>"
+  echo
+  echo "  DELETE a team's functional mailbox"
+  echo "  probation-teams -ns dev -pa N02 -ldu YSNYOR -team T1 -delete"
+  echo
+  exit
+}
+
+read_command_line() {
+  if [ "$1" == "" ]; then
+    usage
+  fi
+  while [ "$1" != "" ]; do
+      case $1 in
+        -ns )       shift
+                    NS_KEY=$1
+                    ;;
+        -pa )       shift
+                    PROBATION_AREA_CODE=$1
+                    ;;
+        -ldu )      shift
+                    LOCAL_DELIVERY_UNIT_CODE=$1
+                    ;;
+        -team )     shift
+                    TEAM_CODE=$1
+                    ;;
+        -update )   COMMAND=update
+                    EMAIL=$1
+                    ;;
+        -delete )   COMMAND=delete
+                    ;;
+        -help )     usage
+                    ;;
+        * )         shift
+                    ;;
+      esac
+      shift
+  done
+}
+
+check_namespace() {
+  case "$NS_KEY" in
+    dev|preprod|prod)
+      NAMESPACE=licences-${NS_KEY};
+    ;;
+    *)
+      echo "-ns must be 'dev', 'preprod' or 'prod'";
+      exit;
+      ;;
+  esac
+}
+
+set_base_url() {
+  if ! [ $PROBATION_AREA_CODE ]; then
+    echo "Probation area code not set."
+    exit
+  fi
+
+  if ! [ $LOCAL_DELIVERY_UNIT_CODE ]; then
+    echo "Local delivery unit code not set."
+    exit
+  fi
+
+  if [ $TEAM_CODE ]; then
+    BASE_URL=${PROBATION_TEAMS_URL[$NS_KEY]}/probation-areas/${PROBATION_AREA_CODE}/local-delivery-units/${LOCAL_DELIVERY_UNIT_CODE}/teams/${TEAM_CODE}
+  else
+    BASE_URL=${PROBATION_TEAMS_URL[$NS_KEY]}/probation-areas/${PROBATION_AREA_CODE}/local-delivery-units/${LOCAL_DELIVERY_UNIT_CODE}
+  fi
+}
+
+get_token() {
+  local NOMIS_AUTH_URL=${AUTH_URL[$NS_KEY]}
+  local API_SECRET=$(kubectl -n ${NAMESPACE} get secret licences -o json | jq -r ".data.ADMIN_API_CLIENT_SECRET | @base64d")
+  local API_ID=$(kubectl -n ${NAMESPACE} get secret licences -o json | jq -r ".data.ADMIN_API_CLIENT_ID | @base64d")
+  local AUTH_BASIC=$(echo -n ${API_ID}:${API_SECRET} | base64 -b0)
+  TOKEN=$(curl -s -X POST "${NOMIS_AUTH_URL}/oauth/token?grant_type=client_credentials" -H 'Content-Type: application/json' -H 'Content-Length: 0' -H "Authorization: Basic ${AUTH_BASIC}" | jq -r '.access_token')
+}
+
+set_auth_header() {
+  AUTH_HEADER="Authorization: Bearer $TOKEN"
+}
+
+confirm() {
+  if [ "${NS_KEY}" == "prod" ]; then
+    local confirm=""
+    echo "This is the PRODUCTION namespace"
+    while [ "${confirm}" != "Y" ] && [ "${confirm}" != "n" ]; do
+      read -p 'Continue? Y/n: ' -n 1 confirm
+      echo
+    done
+    if [ "${confirm}" != "Y" ]; then
+      exit
+    fi
+  fi
+}
+
+get_ldu() {
+  # echo "GET ${BASE_URL}"
+  confirm
+  curl -s -H "${AUTH_HEADER}" -X HEAD ${BASE_URL} -w 'HTTP status: %{http_code}\n'
+  curl -s -H "${AUTH_HEADER}" -X GET ${BASE_URL} | jq
+}
+
+update_mailbox() {
+  if [ $EMAIL ]; then
+    # echo "PUT ${EMAIL}"
+    # echo "  to ${BASE_URL}/functional-mailbox"
+    confirm
+    curl -s -H "${AUTH_HEADER}" -X PUT ${BASE_URL}/functional-mailbox -H 'Content-Type: application/json' -d \"${EMAIL}\" -w 'HTTP status: %{http_code}\n'
+  else
+    echo "No email address"
+    exit
+  fi
+}
+
+delete_mailbox() {
+  # echo "DELETE ${BASE_URL}/functional-mailbox"
+  confirm
+  curl -s -H "${AUTH_HEADER}" -X DELETE ${BASE_URL}/functional-mailbox -w 'HTTP status: %{http_code}\n'
+
+}
+
+do_command() {
+  case $COMMAND in
+    update )
+      update_mailbox
+    ;;
+    delete )
+      delete_mailbox
+    ;;
+    * )
+      get_ldu
+    ;;
+  esac
+}
+
+read_command_line $*
+check_namespace
+set_base_url
+get_token
+set_auth_header
+do_command

--- a/scripts/probation-teams
+++ b/scripts/probation-teams
@@ -50,10 +50,10 @@ usage() {
 }
 
 read_command_line() {
-  if [ "$1" == "" ]; then
+  if [[ ! $1 ]]; then
     usage
   fi
-  while [ "$1" != "" ]; do
+  while [[ $1 ]]; do
       case $1 in
         -ns )       shift
                     NS_KEY=$1
@@ -75,7 +75,10 @@ read_command_line() {
                     ;;
         -help )     usage
                     ;;
-        * )         shift
+        * )         echo
+                    echo "Unknown argument '$1'"
+                    echo
+                    exit
                     ;;
       esac
       shift
@@ -84,9 +87,9 @@ read_command_line() {
 
 check_namespace() {
   case "$NS_KEY" in
-    dev|preprod|prod)
+    dev | preprod | prod )
       NAMESPACE=licences-${NS_KEY};
-    ;;
+      ;;
     *)
       echo "-ns must be 'dev', 'preprod' or 'prod'";
       exit;
@@ -95,17 +98,17 @@ check_namespace() {
 }
 
 set_base_url() {
-  if ! [ $PROBATION_AREA_CODE ]; then
+  if [[ ! $PROBATION_AREA_CODE ]]; then
     echo "Probation area code not set."
     exit
   fi
 
-  if ! [ $LOCAL_DELIVERY_UNIT_CODE ]; then
+  if [[ ! $LOCAL_DELIVERY_UNIT_CODE ]]; then
     echo "Local delivery unit code not set."
     exit
   fi
 
-  if [ $TEAM_CODE ]; then
+  if [[ $TEAM_CODE ]]; then
     BASE_URL=${PROBATION_TEAMS_URL[$NS_KEY]}/probation-areas/${PROBATION_AREA_CODE}/local-delivery-units/${LOCAL_DELIVERY_UNIT_CODE}/teams/${TEAM_CODE}
   else
     BASE_URL=${PROBATION_TEAMS_URL[$NS_KEY]}/probation-areas/${PROBATION_AREA_CODE}/local-delivery-units/${LOCAL_DELIVERY_UNIT_CODE}
@@ -123,33 +126,37 @@ set_auth_header() {
 }
 
 confirm() {
-  if [ "${NS_KEY}" == "prod" ]; then
+  if [[ ${NS_KEY} == "prod" ]]; then
     local confirm=""
     echo "This is the PRODUCTION namespace"
-    while [ "${confirm}" != "Y" ] && [ "${confirm}" != "n" ]; do
+    while [[ ${confirm} != "Y" ]] && [[ ${confirm} != "n" ]]; do
       read -p 'Continue? Y/n: ' -n 1 confirm
       echo
     done
-    if [ "${confirm}" != "Y" ]; then
+    if [[ ${confirm} != "Y" ]]; then
       exit
     fi
   fi
 }
 
 get_ldu() {
+  if [[ $TEAM_CODE ]]; then
+    echo "Don't use '-team' with GET"
+    exit
+  fi
   echo "GET ${BASE_URL}"
   curl -s -H "${AUTH_HEADER}" -X HEAD ${BASE_URL} -w 'HTTP status: %{http_code}\n'
   curl -s -H "${AUTH_HEADER}" -X GET ${BASE_URL} | jq
 }
 
 update_mailbox() {
-  if [ $EMAIL ]; then
+  if [[ $EMAIL ]]; then
     echo "PUT ${EMAIL}"
     echo "  to ${BASE_URL}/functional-mailbox"
     confirm
     curl -s -H "${AUTH_HEADER}" -X PUT ${BASE_URL}/functional-mailbox -H 'Content-Type: application/json' -d \"${EMAIL}\" -w 'HTTP status: %{http_code}\n'
   else
-    echo "No email address"
+    echo "Missing email address for -update"
     exit
   fi
 }
@@ -175,7 +182,7 @@ do_command() {
   esac
 }
 
-read_command_line $*
+read_command_line "$@"
 check_namespace
 set_base_url
 set_auth_header

--- a/scripts/probation-teams
+++ b/scripts/probation-teams
@@ -112,15 +112,13 @@ set_base_url() {
   fi
 }
 
-get_token() {
-  local NOMIS_AUTH_URL=${AUTH_URL[$NS_KEY]}
-  local API_SECRET=$(kubectl -n ${NAMESPACE} get secret licences -o json | jq -r ".data.ADMIN_API_CLIENT_SECRET | @base64d")
-  local API_ID=$(kubectl -n ${NAMESPACE} get secret licences -o json | jq -r ".data.ADMIN_API_CLIENT_ID | @base64d")
-  local AUTH_BASIC=$(echo -n ${API_ID}:${API_SECRET} | base64 -b0)
-  TOKEN=$(curl -s -X POST "${NOMIS_AUTH_URL}/oauth/token?grant_type=client_credentials" -H 'Content-Type: application/json' -H 'Content-Length: 0' -H "Authorization: Basic ${AUTH_BASIC}" | jq -r '.access_token')
-}
-
 set_auth_header() {
+  local NOMIS_AUTH_URL=${AUTH_URL[$NS_KEY]}
+  local SECRETS="$(kubectl -n ${NAMESPACE} get secret licences -o json)"
+  local API_SECRET=$(echo "${SECRETS}" | jq -r ".data.ADMIN_API_CLIENT_SECRET | @base64d")
+  local API_ID=$(echo "${SECRETS}" | jq -r ".data.ADMIN_API_CLIENT_ID | @base64d")
+  local AUTH_BASIC=$(echo -n ${API_ID}:${API_SECRET} | base64 -b0)
+  local TOKEN=$(curl -s -X POST "${NOMIS_AUTH_URL}/oauth/token?grant_type=client_credentials" -H 'Content-Type: application/json' -H 'Content-Length: 0' -H "Authorization: Basic ${AUTH_BASIC}" | jq -r '.access_token')
   AUTH_HEADER="Authorization: Bearer $TOKEN"
 }
 
@@ -180,6 +178,5 @@ do_command() {
 read_command_line $*
 check_namespace
 set_base_url
-get_token
 set_auth_header
 do_command

--- a/src/main/java/uk/gov/justice/hmpps/probationteams/controllers/ProbationAreaController.kt
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/controllers/ProbationAreaController.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.hmpps.probationteams.controllers
 
 import io.swagger.annotations.*
-import  lombok.extern.slf4j.Slf4j
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.ResponseEntity
@@ -19,7 +18,6 @@ import uk.gov.justice.hmpps.probationteams.services.SetOutcome
 @RequestMapping(
         value = ["probation-areas"],
         produces = [APPLICATION_JSON_VALUE])
-@Slf4j
 class ProbationAreaController(val localDeliveryUnitService: LocalDeliveryUnitService) {
 
     @GetMapping(
@@ -46,8 +44,6 @@ class ProbationAreaController(val localDeliveryUnitService: LocalDeliveryUnitSer
                     .getLocalDeliveryUnit(probationAreaCode, localDeliveryUnitCode)
                     .map(::fromLocalDeliveryUnit)
     )
-
-
 
     @PutMapping(
             path = ["/{probationAreaCode}/local-delivery-units/{localDeliveryUnitCode}/functional-mailbox"],
@@ -82,7 +78,6 @@ class ProbationAreaController(val localDeliveryUnitService: LocalDeliveryUnitSer
     }
 
 
-
     @DeleteMapping(path = ["/{probationAreaCode}/local-delivery-units/{localDeliveryUnitCode}/functional-mailbox"])
     @ApiOperation(value = "Delete a Local Delivery Unit's functional mailbox", notes = "Delete a Local Delivery Unit's functional mailbox")
     @ApiResponses(value = [
@@ -108,7 +103,6 @@ class ProbationAreaController(val localDeliveryUnitService: LocalDeliveryUnitSer
                 DeleteOutcome.DELETED -> ResponseEntity.noContent().build()
                 DeleteOutcome.NOT_FOUND -> ResponseEntity.notFound().build()
             }
-
 
 
     @PutMapping(
@@ -149,7 +143,6 @@ class ProbationAreaController(val localDeliveryUnitService: LocalDeliveryUnitSer
     }
 
 
-
     @DeleteMapping(path = ["/{probationAreaCode}/local-delivery-units/{localDeliveryUnitCode}/teams/{teamCode}/functional-mailbox"])
     @ApiOperation(value = "Delete a Probation Teams's functional mailbox", notes = "Delete a Probation Teams's functional mailbox")
     @ApiResponses(value = [
@@ -180,6 +173,7 @@ class ProbationAreaController(val localDeliveryUnitService: LocalDeliveryUnitSer
     }
 
     companion object {
+
         private fun fromLocalDeliveryUnit(ldu: LocalDeliveryUnit) = with(ldu) {
             LocalDeliveryUnitDto(
                     probationAreaCode = probationAreaCode,

--- a/src/main/java/uk/gov/justice/hmpps/probationteams/model/ValidationConstraints.kt
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/model/ValidationConstraints.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.hmpps.probationteams.model
+
+import javax.validation.Constraint
+import javax.validation.ReportAsSingleViolation
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.*
+import kotlin.reflect.KClass
+
+@NotBlank()
+@Pattern(regexp = "^[A-Z0-9_]+$")
+@ReportAsSingleViolation
+@Retention(RUNTIME)
+@Target(VALUE_PARAMETER, PROPERTY, ANNOTATION_CLASS )
+@Constraint(validatedBy = [])
+@MustBeDocumented
+annotation class ProbationAreaCode(
+        val message: String = "Must be a valid Probation Area Code",
+        val groups: Array<KClass<out Any>> = [],
+        val payload: Array<KClass<out Any>> = []
+)
+
+@NotBlank()
+@Pattern(regexp = "^[A-Z0-9_]+$")
+@ReportAsSingleViolation
+@Retention(RUNTIME)
+@Target(VALUE_PARAMETER, PROPERTY, ANNOTATION_CLASS )
+@Constraint(validatedBy = [])
+@MustBeDocumented
+annotation class LduCode(
+        val message: String = "Must be a valid Local Delivery Unit Code",
+        val groups: Array<KClass<out Any>> = [],
+        val payload: Array<KClass<out Any>> = []
+)
+
+@NotBlank()
+@Pattern(regexp = "^[A-Z0-9_]+$")
+@ReportAsSingleViolation
+@Retention(RUNTIME)
+@Target(VALUE_PARAMETER, PROPERTY, ANNOTATION_CLASS )
+@Constraint(validatedBy = [])
+@MustBeDocumented
+annotation class TeamCode(
+        val message: String = "Must be a valid Probation Team Code",
+        val groups: Array<KClass<out Any>> = [],
+        val payload: Array<KClass<out Any>> = []
+)
+
+@NotBlank()
+@Email
+@ReportAsSingleViolation
+@Retention(RUNTIME)
+@Target(VALUE_PARAMETER, PROPERTY, ANNOTATION_CLASS )
+@Constraint(validatedBy = [])
+@MustBeDocumented
+annotation class Email(
+        val message: String = "Must be a valid email address",
+        val groups: Array<KClass<out Any>> = [],
+        val payload: Array<KClass<out Any>> = []
+)

--- a/src/main/java/uk/gov/justice/hmpps/probationteams/services/LocalDeliveryUnitService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/services/LocalDeliveryUnitService.kt
@@ -5,13 +5,9 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.validation.annotation.Validated
-import uk.gov.justice.hmpps.probationteams.model.LocalDeliveryUnit
-import uk.gov.justice.hmpps.probationteams.model.ProbationTeam
+import uk.gov.justice.hmpps.probationteams.model.*
 import uk.gov.justice.hmpps.probationteams.repository.LocalDeliveryUnitRepository
 import java.util.*
-import javax.validation.constraints.Email
-import javax.validation.constraints.NotBlank
-import javax.validation.constraints.Pattern
 
 @Service
 @Validated
@@ -23,9 +19,9 @@ class LocalDeliveryUnitService(@Autowired val repository: LocalDeliveryUnitRepos
 
     @PreAuthorize("hasAnyRole('MAINTAIN_REF_DATA', 'SYSTEM_USER')")
     fun setFunctionalMailbox(
-            @NotBlank @Pattern(regexp = "^[A-Z0-9_]+$", message = "Invalid Probation Area code") probationAreaCode: String,
-            @NotBlank @Pattern(regexp = "^[A-Z0-9_]+$", message = "Invalid Local Delivery Unit code") localDeliveryUnitCode: String,
-            @NotBlank @Email proposedFunctionalMailbox: String): SetOutcome =
+            @ProbationAreaCode probationAreaCode: String,
+            @LduCode localDeliveryUnitCode: String,
+            @Email proposedFunctionalMailbox: String): SetOutcome =
 
             getLocalDeliveryUnit(probationAreaCode, localDeliveryUnitCode)
                     .map { ldu -> updateLduFunctionalMailbox(ldu, proposedFunctionalMailbox) }
@@ -40,10 +36,10 @@ class LocalDeliveryUnitService(@Autowired val repository: LocalDeliveryUnitRepos
 
     @PreAuthorize("hasAnyRole('MAINTAIN_REF_DATA', 'SYSTEM_USER')")
     fun setFunctionalMailbox(
-            @NotBlank @Pattern(regexp = "^[A-Z0-9_]+$", message = "Invalid Probation Area code") probationAreaCode: String,
-            @NotBlank @Pattern(regexp = "^[A-Z0-9_]+$", message = "Invalid Local Delivery Unit code") localDeliveryUnitCode: String,
-            @NotBlank @Pattern(regexp = "^[A-Z0-9_]+$", message = "Invalid Team code") teamCode: String,
-            @NotBlank @Email proposedFunctionalMailbox: String): SetOutcome =
+            @ProbationAreaCode probationAreaCode: String,
+            @LduCode localDeliveryUnitCode: String,
+            @TeamCode teamCode: String,
+            @Email proposedFunctionalMailbox: String): SetOutcome =
 
             getLocalDeliveryUnit(probationAreaCode, localDeliveryUnitCode)
                     .map { ldu -> setTeamFunctionalMailbox(ldu, teamCode, proposedFunctionalMailbox) }
@@ -58,8 +54,8 @@ class LocalDeliveryUnitService(@Autowired val repository: LocalDeliveryUnitRepos
 
     @PreAuthorize("hasAnyRole('MAINTAIN_REF_DATA', 'SYSTEM_USER')")
     fun deleteFunctionalMailbox(
-            @NotBlank @Pattern(regexp = "^[A-Z0-9_]+$", message = "Invalid Probation Area code") probationAreaCode: String,
-            @NotBlank @Pattern(regexp = "^[A-Z0-9_]+$", message = "Invalid Local Delivery Unit code") localDeliveryUnitCode: String
+            @ProbationAreaCode probationAreaCode: String,
+            @LduCode localDeliveryUnitCode: String
     ): DeleteOutcome =
 
             getLocalDeliveryUnit(probationAreaCode, localDeliveryUnitCode)
@@ -68,16 +64,16 @@ class LocalDeliveryUnitService(@Autowired val repository: LocalDeliveryUnitRepos
 
     @PreAuthorize("hasAnyRole('MAINTAIN_REF_DATA', 'SYSTEM_USER')")
     fun deleteFunctionalMailbox(
-            @NotBlank @Pattern(regexp = "^[A-Z0-9_]+$", message = "Invalid Probation Area code") probationAreaCode: String,
-            @NotBlank @Pattern(regexp = "^[A-Z0-9_]+$", message = "Invalid Local Delivery Unit code") localDeliveryUnitCode: String,
-            @NotBlank @Pattern(regexp = "^[A-Z0-9_]+$", message = "Invalid Team code") teamCode: String
+            @ProbationAreaCode probationAreaCode: String,
+            @LduCode localDeliveryUnitCode: String,
+            @TeamCode teamCode: String
     ): DeleteOutcome =
 
             getLocalDeliveryUnit(probationAreaCode, localDeliveryUnitCode)
                     .map { ldu -> doDeleteFmb(ldu, teamCode) }
                     .orElse(DeleteOutcome.NOT_FOUND)
 
-    private fun updateLduFunctionalMailbox(ldu: LocalDeliveryUnit, proposedFunctionalMailbox: @Email String): SetOutcome =
+    private fun updateLduFunctionalMailbox(ldu: LocalDeliveryUnit, proposedFunctionalMailbox: String): SetOutcome =
             when (ldu.functionalMailbox) {
                 null -> {
                     ldu.functionalMailbox = proposedFunctionalMailbox

--- a/src/test/java/uk/gov/justice/hmpps/probationteams/controllers/ProbationAreaResourceIntegrationTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/probationteams/controllers/ProbationAreaResourceIntegrationTest.kt
@@ -231,7 +231,7 @@ class ProbationAreaResourceIntegrationTest(
             assertThat(response.statusCode).isEqualTo(testData.expectedStatusCode)
             if (testData.expectedMessage != null) {
                 val content = jsonTester.from(response.body)
-                assertThat(content).extractingJsonPathStringValue("$.developerMessage").contains(testData.expectedMessage)
+                assertThat(content).extractingJsonPathStringValue("$.developerMessage").endsWith(testData.expectedMessage)
             }
         }
 
@@ -275,32 +275,32 @@ class ProbationAreaResourceIntegrationTest(
         )
 
         val invalidProbationAreaCodes = listOf(
-                ValidationTestData("a", HttpStatus.BAD_REQUEST, "probationAreaCode: Invalid Probation Area code"),
-                ValidationTestData("-", HttpStatus.BAD_REQUEST, "probationAreaCode: Invalid Probation Area code"),
-                ValidationTestData(" ", HttpStatus.BAD_REQUEST, "probationAreaCode: must not be blank"),
+                ValidationTestData("a", HttpStatus.BAD_REQUEST, INVALID_PROBATION_AREA_MESSAGE),
+                ValidationTestData("-", HttpStatus.BAD_REQUEST, INVALID_PROBATION_AREA_MESSAGE),
+                ValidationTestData(" ", HttpStatus.BAD_REQUEST, INVALID_PROBATION_AREA_MESSAGE),
                 ValidationTestData("", HttpStatus.NOT_FOUND, null)
         )
 
         val invalidLocalDeliveryUnitCodes2 = listOf(
-                ValidationTestData("a", HttpStatus.BAD_REQUEST, "localDeliveryUnitCode: Invalid Local Delivery Unit code"),
-                ValidationTestData("-", HttpStatus.BAD_REQUEST, "localDeliveryUnitCode: Invalid Local Delivery Unit code"),
-                ValidationTestData(" ", HttpStatus.BAD_REQUEST, "localDeliveryUnitCode: must not be blank"),
+                ValidationTestData("a", HttpStatus.BAD_REQUEST, INVALID_LDU_MESSAGE),
+                ValidationTestData("-", HttpStatus.BAD_REQUEST, INVALID_LDU_MESSAGE),
+                ValidationTestData(" ", HttpStatus.BAD_REQUEST, INVALID_LDU_MESSAGE),
                 ValidationTestData("", HttpStatus.NOT_FOUND, null)
         )
 
         val invalidLocalDeliveryUnitCodes1 = invalidLocalDeliveryUnitCodes2.map(::adaptTestData)
 
         val invalidTeamCodes = listOf(
-                ValidationTestData("a", HttpStatus.BAD_REQUEST, "teamCode: Invalid Team code"),
-                ValidationTestData("-", HttpStatus.BAD_REQUEST, "teamCode: Invalid Team code"),
-                ValidationTestData(" ", HttpStatus.BAD_REQUEST, "teamCode: must not be blank"),
+                ValidationTestData("a", HttpStatus.BAD_REQUEST, INVALID_TEAM_CODE_MESSAGE),
+                ValidationTestData("-", HttpStatus.BAD_REQUEST, INVALID_TEAM_CODE_MESSAGE),
+                ValidationTestData(" ", HttpStatus.BAD_REQUEST, INVALID_TEAM_CODE_MESSAGE),
                 ValidationTestData("", HttpStatus.NOT_FOUND, null)
         )
 
         val invalidEmailAddresses = listOf(
-                ValidationTestData("abc.def.com", HttpStatus.BAD_REQUEST, "must be a well-formed email address"),
-                ValidationTestData(" ", HttpStatus.BAD_REQUEST, "must not be blank"),
-                ValidationTestData("", HttpStatus.BAD_REQUEST, "must not be blank")
+                ValidationTestData("abc.def.com", HttpStatus.BAD_REQUEST, INVALID_EMAIL_MESSAGE),
+                ValidationTestData(" ", HttpStatus.BAD_REQUEST, INVALID_EMAIL_MESSAGE),
+                ValidationTestData("", HttpStatus.BAD_REQUEST, INVALID_EMAIL_MESSAGE)
         )
     }
 
@@ -361,6 +361,11 @@ class ProbationAreaResourceIntegrationTest(
         private val MAINTAIN_REF_DATA_ROLE = listOf("ROLE_MAINTAIN_REF_DATA")
 
         private val SYSTEM_USER_ROLE = listOf("ROLE_SYSTEM_USER")
+
+        private const val INVALID_PROBATION_AREA_MESSAGE = "Must be a valid Probation Area Code"
+        private const val INVALID_LDU_MESSAGE = "Must be a valid Local Delivery Unit Code"
+        private const val INVALID_TEAM_CODE_MESSAGE = "Must be a valid Probation Team Code"
+        private const val INVALID_EMAIL_MESSAGE = "Must be a valid email address"
     }
 }
 

--- a/src/test/java/uk/gov/justice/hmpps/probationteams/repository/LocalDeliveryUnitRepositoryTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/probationteams/repository/LocalDeliveryUnitRepositoryTest.kt
@@ -40,21 +40,16 @@ class LocalDeliveryUnitRepositoryTest(
         TestTransaction.end()
 
         TestTransaction.start()
-        val optionalOfLDU = repository.findByProbationAreaCodeAndLocalDeliveryUnitCode("ABC", lduCode)
 
-        assertThat(optionalOfLDU).isPresent
+        assertThat(repository.findByProbationAreaCodeAndLocalDeliveryUnitCode("ABC", lduCode))
+                .hasValueSatisfying { persistentLdu ->
+                    assertThat(persistentLdu.id).isNotNull()
 
-        optionalOfLDU.ifPresent { persistentLdu ->
-            assertThat(persistentLdu.id).isNotNull()
-
-            // Business key equality
-            assertThat(persistentLdu).isEqualTo(ldu)
-
-            assertThat(ldu.createUserId).isEqualTo("anonymous")
-
-            // Check the db...
-            assertThat(lduCount(persistentLdu.id)).isEqualTo(1)
-        }
+                    // Business key equality
+                    assertThat(persistentLdu).isEqualTo(ldu)
+                    assertThat(ldu.createUserId).isEqualTo("anonymous")
+                    assertThat(lduCount(persistentLdu.id)).isEqualTo(1)
+                }
     }
 
     @Test
@@ -67,14 +62,12 @@ class LocalDeliveryUnitRepositoryTest(
         TestTransaction.end()
 
         TestTransaction.start()
-        val optionalOfLdu = repository.findByProbationAreaCodeAndLocalDeliveryUnitCode("ABC", lduCode)
-        assertThat(optionalOfLdu).isPresent
-
-        optionalOfLdu.ifPresent { persistentLdu ->
-            assertThat(persistentLdu.id).isNotNull()
-            assertThat(persistentLdu.probationTeams).isEqualTo(lduWithProbationTeams(lduCode).probationTeams)
-            assertThat(probationTeamCount(persistentLdu.id)).isEqualTo(2)
-        }
+        assertThat(repository.findByProbationAreaCodeAndLocalDeliveryUnitCode("ABC", lduCode))
+                .hasValueSatisfying { persistentLdu ->
+                    assertThat(persistentLdu.id).isNotNull()
+                    assertThat(persistentLdu.probationTeams).isEqualTo(lduWithProbationTeams(lduCode).probationTeams)
+                    assertThat(probationTeamCount(persistentLdu.id)).isEqualTo(2)
+                }
     }
 
 
@@ -88,31 +81,23 @@ class LocalDeliveryUnitRepositoryTest(
 
         TestTransaction.start()
 
-        val persistentLduOpt = repository
-                .findByProbationAreaCodeAndLocalDeliveryUnitCode("ABC", lduCode)
-
-        assertThat(persistentLduOpt).isPresent
-
-        persistentLduOpt.ifPresent { persistentLdu ->
-            persistentLdu.probationTeams.remove("T1")
-            persistentLdu.probationTeams["T2"] = ProbationTeam("zzz@zzz.com")
-        }
+        assertThat(repository.findByProbationAreaCodeAndLocalDeliveryUnitCode("ABC", lduCode))
+                .hasValueSatisfying { persistentLdu ->
+                    persistentLdu.probationTeams.remove("T1")
+                    persistentLdu.probationTeams["T2"] = ProbationTeam("zzz@zzz.com")
+                }
 
         TestTransaction.flagForCommit()
         TestTransaction.end()
 
         TestTransaction.start()
 
-        val updatedPersistentLduOpt = repository
-                .findByProbationAreaCodeAndLocalDeliveryUnitCode("ABC", lduCode)
-
-        assertThat(updatedPersistentLduOpt).isPresent
-
-        updatedPersistentLduOpt.ifPresent { persistentLdu ->
-            assertThat(persistentLdu.id).isNotNull()
-            assertThat(persistentLdu.probationTeams).isEqualTo(mutableMapOf("T2" to ProbationTeam("zzz@zzz.com")))
-            assertThat(probationTeamCount(persistentLdu.id)).isEqualTo(1)
-        }
+        assertThat(repository.findByProbationAreaCodeAndLocalDeliveryUnitCode("ABC", lduCode))
+                .hasValueSatisfying { persistentLdu ->
+                    assertThat(persistentLdu.id).isNotNull()
+                    assertThat(persistentLdu.probationTeams).isEqualTo(mutableMapOf("T2" to ProbationTeam("zzz@zzz.com")))
+                    assertThat(probationTeamCount(persistentLdu.id)).isEqualTo(1)
+                }
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/hmpps/probationteams/repository/LocalDeliveryUnitRepositoryTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/probationteams/repository/LocalDeliveryUnitRepositoryTest.kt
@@ -95,7 +95,7 @@ class LocalDeliveryUnitRepositoryTest(
         assertThat(repository.findByProbationAreaCodeAndLocalDeliveryUnitCode("ABC", lduCode))
                 .hasValueSatisfying { persistentLdu ->
                     assertThat(persistentLdu.id).isNotNull()
-                    assertThat(persistentLdu.probationTeams).isEqualTo(mutableMapOf("T2" to ProbationTeam("zzz@zzz.com")))
+                    assertThat(persistentLdu.probationTeams).isEqualTo(mapOf("T2" to ProbationTeam("zzz@zzz.com")))
                     assertThat(probationTeamCount(persistentLdu.id)).isEqualTo(1)
                 }
     }


### PR DESCRIPTION
This is three commits:

1. A bash script to help with querying, updating and deleting functional mailboxes using the probation-teams REST API.  Depends on jq and kubectl

1. Very small changes to the probation-teams service:
- Remove dependencies on Lombok from gradle build. Lombok wasn't being used
- Improve a test

1. Created composed validation constraints for Probation Area Code, LDU Code, Team Code and Email
