### PR TITLE
DCS-253 Add an administrative UI for the LDU to Functional Mailbox mapping

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/probationteams/controllers/ProbationAreaController.kt
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/controllers/ProbationAreaController.kt
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import uk.gov.justice.hmpps.probationteams.dto.ErrorResponse
 import uk.gov.justice.hmpps.probationteams.dto.LocalDeliveryUnitDto
+import uk.gov.justice.hmpps.probationteams.dto.ProbationAreaDto
 import uk.gov.justice.hmpps.probationteams.dto.ProbationTeamDto
 import uk.gov.justice.hmpps.probationteams.model.LocalDeliveryUnit
 import uk.gov.justice.hmpps.probationteams.services.DeleteOutcome
@@ -19,6 +20,29 @@ import uk.gov.justice.hmpps.probationteams.services.SetOutcome
         value = ["probation-areas"],
         produces = [APPLICATION_JSON_VALUE])
 class ProbationAreaController(val localDeliveryUnitService: LocalDeliveryUnitService) {
+
+    @GetMapping(
+            path = ["/{probationAreaCode}"],
+            produces = [APPLICATION_JSON_VALUE])
+
+    @ApiOperation(value = "Retrieve a Probation Area", nickname = "Retrieve a Probation Area")
+    @ApiResponses(value = [
+        ApiResponse(code = 404, message = "Probation Area not found"),
+        ApiResponse(code = 200, message = "OK", response = ProbationAreaDto::class)
+    ])
+    fun getProbationArea(
+
+            @ApiParam(value = "Probation Area code", required = true, example = "N02")
+            @PathVariable("probationAreaCode")
+            probationAreaCode: String
+
+    ): ProbationAreaDto =
+            ProbationAreaDto(
+                    probationAreaCode,
+                    localDeliveryUnitService
+                            .getProbationArea(probationAreaCode)
+                            .map(::fromLocalDeliveryUnit)
+                            .associateBy(LocalDeliveryUnitDto::localDeliveryUnitCode))
 
     @GetMapping(
             path = ["/{probationAreaCode}/local-delivery-units/{localDeliveryUnitCode}"],
@@ -184,3 +208,4 @@ class ProbationAreaController(val localDeliveryUnitService: LocalDeliveryUnitSer
         }
     }
 }
+

--- a/src/main/java/uk/gov/justice/hmpps/probationteams/controllers/ProbationAreaController.kt
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/controllers/ProbationAreaController.kt
@@ -27,7 +27,6 @@ class ProbationAreaController(val localDeliveryUnitService: LocalDeliveryUnitSer
 
     @ApiOperation(value = "Retrieve a Probation Area", nickname = "Retrieve a Probation Area")
     @ApiResponses(value = [
-        ApiResponse(code = 404, message = "Probation Area not found"),
         ApiResponse(code = 200, message = "OK", response = ProbationAreaDto::class)
     ])
     fun getProbationArea(

--- a/src/main/java/uk/gov/justice/hmpps/probationteams/dto/ProbationAreaDto.kt
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/dto/ProbationAreaDto.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.hmpps.probationteams.dto
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.ApiModel
+import io.swagger.annotations.ApiModelProperty
+import javax.validation.constraints.NotBlank
+
+@ApiModel(description = "Probation Area")
+data class ProbationAreaDto @JsonCreator constructor(
+        @ApiModelProperty(required = true, value = "Probation Area code", position = 1, example = "NO2")
+        @JsonProperty("probationAreaCode")
+        val probationAreaCode: @NotBlank String,
+
+        @ApiModelProperty(required = true, value = "Local Delivery Units by Local Delivery Unit code", position = 2)
+        @JsonProperty("localDeliveryUnits")
+        val localDeliveryUnits: Map<String, LocalDeliveryUnitDto>? = mapOf()
+)

--- a/src/main/java/uk/gov/justice/hmpps/probationteams/dto/ProbationAreaDto.kt
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/dto/ProbationAreaDto.kt
@@ -14,5 +14,5 @@ data class ProbationAreaDto @JsonCreator constructor(
 
         @ApiModelProperty(required = true, value = "Local Delivery Units by Local Delivery Unit code", position = 2)
         @JsonProperty("localDeliveryUnits")
-        val localDeliveryUnits: Map<String, LocalDeliveryUnitDto>? = mapOf()
+        val localDeliveryUnits: Map<String, LocalDeliveryUnitDto> = mapOf()
 )

--- a/src/main/java/uk/gov/justice/hmpps/probationteams/repository/LocalDeliveryUnitRepository.kt
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/repository/LocalDeliveryUnitRepository.kt
@@ -7,5 +7,6 @@ import java.util.*
 
 @Repository
 interface LocalDeliveryUnitRepository : JpaRepository<LocalDeliveryUnit, UUID> {
+    fun findByProbationAreaCode(probationAreaCode: String): List<LocalDeliveryUnit>
     fun findByProbationAreaCodeAndLocalDeliveryUnitCode(probationAreaCode: String, localDeliveryUnitCode: String): Optional<LocalDeliveryUnit>
 }

--- a/src/main/java/uk/gov/justice/hmpps/probationteams/services/LocalDeliveryUnitService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/probationteams/services/LocalDeliveryUnitService.kt
@@ -14,6 +14,9 @@ import java.util.*
 @Transactional
 class LocalDeliveryUnitService(@Autowired val repository: LocalDeliveryUnitRepository) {
 
+    fun getProbationArea(probationAreaCode: String): List<LocalDeliveryUnit> =
+            repository.findByProbationAreaCode(probationAreaCode)
+
     fun getLocalDeliveryUnit(probationAreaCode: String, localDeliveryUnitCode: String): Optional<LocalDeliveryUnit> =
             repository.findByProbationAreaCodeAndLocalDeliveryUnitCode(probationAreaCode, localDeliveryUnitCode)
 

--- a/src/test/java/uk/gov/justice/hmpps/probationteams/controllers/ProbationAreaResourceIntegrationTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/probationteams/controllers/ProbationAreaResourceIntegrationTest.kt
@@ -30,6 +30,28 @@ class ProbationAreaResourceIntegrationTest(
     val jsonTester = BasicJsonTester(this.javaClass)
 
     @Nested
+    @DisplayName("GET ${PROBATION_AREA_TEMPLATE}")
+    inner class GetProbationAreaTests {
+        @Test
+        fun `A Probation area that doesn't contain any FMBs`() {
+            val response = getProbationArea("ZZZ")
+            with(response) {
+                assertThat(statusCode).isEqualTo(HttpStatus.OK)
+                assertThat(jsonTester.from(body)).isEqualToJson("{ probationAreaCode: \"ZZZ\"}")
+            }
+        }
+
+        @Test
+        fun `A probation area that contains FMBs`() {
+            val response = getProbationArea("ABC")
+            with(response) {
+                assertThat(statusCode).isEqualTo(HttpStatus.OK)
+                assertThat(jsonTester.from(body)).isEqualToJson("probationArea.json")
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("GET ${LDU_TEMPLATE}")
     inner class GetLduTests {
         @Test
@@ -304,6 +326,16 @@ class ProbationAreaResourceIntegrationTest(
         )
     }
 
+    fun getProbationArea(probationAreaCode: String): ResponseEntity<String> =
+            testRestTemplate.exchange(
+                    PROBATION_AREA_TEMPLATE,
+                    HttpMethod.GET,
+                    entityBuilder.entityWithJwtAuthorisation(A_USER, NO_ROLES),
+                    String::class.java,
+                    probationAreaCode)
+
+
+
     fun getLdu(probationAreaCode: String, lduCode: String): ResponseEntity<String> =
             testRestTemplate.exchange(
                     LDU_TEMPLATE,
@@ -345,6 +377,7 @@ class ProbationAreaResourceIntegrationTest(
                     probationAreaCode, lduCode, teamCode)
 
     companion object {
+        private const val PROBATION_AREA_TEMPLATE = "/probation-areas/{probationAreaCode}"
         private const val LDU_TEMPLATE = "/probation-areas/{probationAreaCode}/local-delivery-units/{lduCode}"
         private const val LDU_FMB_TEMPLATE = "/probation-areas/{probationAreaCode}/local-delivery-units/{lduCode}/functional-mailbox"
 

--- a/src/test/java/uk/gov/justice/hmpps/probationteams/repository/LocalDeliveryUnitRepositoryTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/probationteams/repository/LocalDeliveryUnitRepositoryTest.kt
@@ -128,6 +128,21 @@ class LocalDeliveryUnitRepositoryTest(
         assertThat(probationTeamCount(lduId)).isEqualTo(0)
     }
 
+    @Test
+    fun findByProbationAreaCode() {
+        val probationAreaCode = "XYZ"
+        repository.save(lduWithProbationTeams(uniqueLduCode(), probationAreaCode))
+        repository.save(lduWithProbationTeams(uniqueLduCode(), probationAreaCode))
+        repository.save(lduWithProbationTeams(uniqueLduCode(), probationAreaCode))
+
+        TestTransaction.flagForCommit()
+        TestTransaction.end()
+        TestTransaction.start()
+
+        val ldus = repository.findByProbationAreaCode(probationAreaCode)
+        assertThat(ldus).hasSize(3)
+    }
+
     private fun probationTeamCount(lduId: UUID?) =
             jdbcTemplate.queryForObject("""
                 select count(*) 
@@ -143,8 +158,8 @@ class LocalDeliveryUnitRepositoryTest(
                  """.trimIndent(), Long::class.java, lduId)
 
     companion object {
-        fun lduWithProbationTeams(lduCode: String): LocalDeliveryUnit = LocalDeliveryUnit(
-                probationAreaCode = "ABC",
+        fun lduWithProbationTeams(lduCode: String, probationAreaCode: String = "ABC"): LocalDeliveryUnit = LocalDeliveryUnit(
+                probationAreaCode,
                 localDeliveryUnitCode = lduCode,
                 probationTeams = mutableMapOf(
                         "T1" to ProbationTeam("t1@team.com"),

--- a/src/test/java/uk/gov/justice/hmpps/probationteams/services/LocalDeliveryUnitServiceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/probationteams/services/LocalDeliveryUnitServiceTest.kt
@@ -27,6 +27,24 @@ class LocalDeliveryUnitServiceTest {
     }
 
     @Nested
+    @DisplayName("getProbationArea()")
+    inner class GetProbationArea {
+
+        @Test
+        fun `Probation area exists`() {
+            every { repository.findByProbationAreaCode(PROBATION_AREA_CODE) } returns listOf(lduWithFmb())
+            assertThat(service.getProbationArea(PROBATION_AREA_CODE)).isNotEmpty
+        }
+
+        @Test
+        fun `Probation area does not exist`() {
+            every { repository.findByProbationAreaCode(PROBATION_AREA_CODE) } returns listOf()
+            assertThat(service.getProbationArea(PROBATION_AREA_CODE)).isEmpty()
+        }
+    }
+
+
+    @Nested
     @DisplayName("getLocalDeliveryUnit()")
     inner class GetLdu {
 

--- a/src/test/resources/uk/gov/justice/hmpps/probationteams/controllers/probationArea.json
+++ b/src/test/resources/uk/gov/justice/hmpps/probationteams/controllers/probationArea.json
@@ -1,0 +1,26 @@
+{
+  "probationAreaCode": "ABC",
+  "localDeliveryUnits": {
+    "ABC124": {
+      "probationAreaCode": "ABC",
+      "localDeliveryUnitCode": "ABC124",
+      "functionalMailbox": "c@d.org",
+      "probationTeams": {}
+    },
+    "ABC125": {
+      "probationAreaCode": "ABC",
+      "localDeliveryUnitCode": "ABC125",
+      "probationTeams": {
+        "TEAM_1": {
+          "functionalMailbox": "t1@b.com"
+        },
+        "TEAM_2": {
+          "functionalMailbox": "t2@b.com"
+        },
+        "TEAM_3": {
+          "functionalMailbox": "t3@b.com"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a new end-point to return all ldu and team -> FMB mappings for a probation area.
`GET /probation-areas/{probationAreaCode}`