### PR TITLE
DCS-902 Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.0.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.1"
 
-  kotlin("plugin.spring") version "1.4.21"
-  kotlin("plugin.jpa") version "1.4.21"
+  kotlin("plugin.spring") version "1.4.31"
+  kotlin("plugin.jpa") version "1.4.31"
 }
 
 configurations {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updated Gradle and the Gradle plugins:
* `uk.gov.justice.hmpps.gradle-spring-boot`
* `plugin.spring` 
* `plugin.jpa`

With these changes in place the `./gradlew dependencyCheckAnalyze --info` task passes without any problems.