### PR TITLE
⬆️ DCS-1366: Bump gradle-spring-boot version to 3.3.16

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.15"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.16"
 
   kotlin("plugin.spring") version "1.5.31"
   kotlin("plugin.jpa") version "1.5.31"


### PR DESCRIPTION
⬆️ DCS-1366: Bump gradle-spring-boot version to 3.3.16