### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/probation-teams/values.yaml
+++ b/helm_deploy/probation-teams/values.yaml
@@ -1,4 +1,3 @@
----
 # Values here are the same across all environments
 
 generic-service:
@@ -8,12 +7,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/probation-teams
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: probation-teams-cert
     path: /
     v1_2_enabled: true
@@ -44,14 +43,8 @@ generic-service:
       SUPERUSER_PASSWORD: "database_password"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    global-protect: "35.176.93.186/32"
-    petty-france-wifi: "213.121.161.112/28"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: probation-teams


### PR DESCRIPTION
[{"path":"helm_deploy/probation-teams/values.yaml","entriesAddedFromGroupMembership":[],"sizeChangeOfDefinedAllowList":"8 => 0 (8 removed)","newList":{"groups":["INTERNAL"],"allowList":[]}}]

This PR migrates the project to use groups of IPs in their allowlist.
By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If changes are required to these list then we can change the definition and future deploys will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.


**file:** helm_deploy/probation-teams/values.yaml
The effect of applying this PR is as follows:

- The following groups will be applied: INTERNAL
- The size of the allowlist defined in this file will change: 8 => 0 (8 removed)


Merging this PR will not result in any additional IP addresses being added to the allowlist.


