### PR TITLE
CVSL-2399 enabling scheduled downtime

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,5 +12,8 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     OAUTH_ENDPOINT_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
 
+  scheduledDowntime:
+    enabled: true
+
 generic-prometheus-alerts:
   alertSeverity: cvl-alerts-non-prod


### PR DESCRIPTION
This will shut down pods between 10pm - 6:30am UTC on weekdays and all day on weekends. 6:30am was chosen as the RDS startup happens between 6am and 6:30am.